### PR TITLE
fix: load temp on page load and auto-update on C/F toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
     <input id="check-input-log" name="check-input-log" class="input" type="range" placeholder="Enter longitude" min="-180" max="180" step="0.001">
     <input type="text" id="textLongitude" disabled>
 
-    <button id="check-button" class="button" type="submit" onclick="findMyGeolocation()">Check</button>
+    <button id="check-button" class="button" type="button">Check</button>
   </section>
 
   <!-- Choose between Fahrenheit and Celsius -->

--- a/js/geolocation.js
+++ b/js/geolocation.js
@@ -39,6 +39,14 @@ $("#wrapper-geolocation").ready(function () {
 
       printLocation (lat, lon);
 
+      // Fetch weather once geolocation is available (#46)
+      if (typeof getTemperatureChoice === 'function') {
+        getTemperatureChoice();
+      }
+      if (typeof getWeather === 'function') {
+        getWeather();
+      }
+
     });
   }
 });

--- a/js/weather.js
+++ b/js/weather.js
@@ -129,10 +129,8 @@ window.onload = function() {
   weatherCity = document.getElementById('city');
   weatherImage = document.getElementById('image');
   weatherDescription = document.getElementById('description');
-  // getLatLogvalues();
-  // readUrlParams();
   getTemperatureChoice();
   checkWeather();
-  getWeather();
+  // getWeather() is now called from geolocation.js after lat/lon are set (#46)
   shareOnTwitter();
 }


### PR DESCRIPTION
## Summary
- Fixed temperature not loading on page load by triggering `getWeather()` from the geolocation callback after lat/lon coordinates are available
- Removed premature `getWeather()` call from `window.onload` (coordinates weren't set yet)
- Fixed Check button which was calling undefined `findMyGeolocation()`
- C/F radio toggle now properly refreshes temperature display

Resolves #46, resolves #48, resolves #39

## Test plan
- [ ] Verify temperature loads automatically on page load (after allowing geolocation)
- [ ] Toggle between C and F and verify temp updates without clicking Check
- [ ] Use lat/lon sliders and click Check to verify manual location works

🤖 Generated with [Claude Code](https://claude.com/claude-code)